### PR TITLE
Update core.rb

### DIFF
--- a/lib/bio/shell/core.rb
+++ b/lib/bio/shell/core.rb
@@ -7,6 +7,8 @@
 #
 #
 
+require 'readline' if RUBY_VERSION >= '3'
+
 module Bio::Shell::Core
 
   SHELLDIR = "shell"


### PR DESCRIPTION
On further testing, I realized that the loaded command history is actually that of Ruby’s plain irb. Further investigation is needed, and please disregard this PR if that is appropriate.

----- original pull request -------

This commit fixes an error "core.rb:400:in `block in load_history_file': uninitialized constant Bio::Shell::Ghost::Readline (NameError)" when the bioruby shell is started and the history file exists in ruby version 3 and up.

This is caused because Ruby 3 does not include Readline module as builtin library. Adding "require 'readline' if RUBY_VERSION >= '3'" solved the error caused in load_history_file when calling Readline.
